### PR TITLE
Fix remove canonical link duplicate.

### DIFF
--- a/themes/eiger/templates/entry.mtml
+++ b/themes/eiger/templates/entry.mtml
@@ -5,7 +5,6 @@
     <meta name="description" content="<$mt:EntryExcerpt remove_html="1" encode_html="1"$>">
     <meta name="generator" content="<$mt:ProductName version="1"$>">
     <title><$mt:EntryTitle encode_html="1"$> - <$mt:BlogName encode_html="1"$></title>
-    <link rel="canonical" href="<$mt:EntryPermalink encode_html="1"$>">
     <$mt:Include module="<__trans phrase="HTML Head">"$>
     <mt:EntryPrevious><link rel="prev" href="<$mt:EntryPermalink encode_html="1"$>" title="<$mt:EntryTitle encode_html="1"$>"></mt:EntryPrevious>
     <mt:EntryNext><link rel="next" href="<$mt:EntryPermalink encode_html="1"$>" title="<$mt:EntryTitle encode_html="1"$>"></mt:EntryNext>

--- a/themes/eiger/templates/index_page.mtml
+++ b/themes/eiger/templates/index_page.mtml
@@ -4,7 +4,6 @@
     <meta charset="<$mt:PublishCharset$>">
     <mt:If tag="BlogDescription"><meta name="description" content="<$mt:BlogDescription remove_html="1" encede_html="1"$>"></mt:If>
     <title><$mt:BlogName encode_html="1"$></title>
-    <link rel="canonical" href="<$mt:BlogURL encode_html="1"$>">
     <$mt:Include module="<__trans phrase="HTML Head">"$>
     <!-- Open Graph Protocol -->
     <meta property="og:type" content="article">

--- a/themes/eiger/templates/main_index.mtml
+++ b/themes/eiger/templates/main_index.mtml
@@ -16,7 +16,6 @@
     <meta charset="<$mt:PublishCharset$>">
     <mt:If tag="BlogDescription"><meta name="description" content="<$mt:BlogDescription remove_html="1" encede_html="1"$>"></mt:If>
     <title><__trans phrase="Blog"> - <$mt:BlogName encode_html="1"$></title>
-    <link rel="canonical" href="<$mt:BlogURL encode_html="1"$>blog/">
     <$mt:Include module="<__trans phrase="HTML Head">"$>
     <!-- Open Graph Protocol -->
     <meta property="og:type" content="article">

--- a/themes/eiger/templates/page.mtml
+++ b/themes/eiger/templates/page.mtml
@@ -5,7 +5,6 @@
     <meta name="description" content="<$mt:PageExcerpt remove_html="1" encode_html="1"$>">
     <meta name="generator" content="<$mt:ProductName version="1"$>">
     <title><$mt:PageTitle encode_html="1"$> - <$mt:BlogName encode_html="1"$></title>
-    <link rel="canonical" href="<$mt:PagePermalink encode_html="1"$>">
     <$mt:Include module="<__trans phrase="HTML Head">"$>
     <!-- Open Graph Protocol -->
     <meta property="og:type" content="article">


### PR DESCRIPTION
Because the `mt:CanonicalLink` tag is included in `html_head.mtml` some templates output has duplicate canonical link.
