### PR TITLE
Fix some phrase are not translated in japanese.

### DIFF
--- a/themes/eiger/l10n_ja.yaml
+++ b/themes/eiger/l10n_ja.yaml
@@ -52,7 +52,7 @@ Navigation: 'ナビゲーション'
 The sign-in attempt was not successful; please try again.: 'サインインできませんでした。'
 Menu: メニュー
 Links: リンク
-By default, this search engine looks for all words in any order. To search for an exact phrase, enclose the phrase in quotes\:: 'すべての単語が順序に関係なく検索されます。フレーズで検索したいときは引用符で囲んでください。'
-The search engine also supports AND, OR, and NOT keywords to specify boolean expressions\:: 'AND、OR、NOTを入れることで論理検索を行うこともできます。'
+By default, this search engine looks for all words in any order. To search for an exact phrase, enclose the phrase in quotes:: 'すべての単語が順序に関係なく検索されます。フレーズで検索したいときは引用符で囲んでください。'
+The search engine also supports AND, OR, and NOT keywords to specify boolean expressions:: 'AND、OR、NOTを入れることで論理検索を行うこともできます。'
 Blog Index: ブログ用インデックスページ
 Displays errors for dynamically-published templates.: 'ダイナミックパブリッシングのエラーを表示します。'


### PR DESCRIPTION
Some phrase are not translated in japanese since 1322df757bedb3be4453253e39dcabe78be14d64 was committed.
Other language has no it problem, because they using `MT/L10N/*.pm` when translated.

A key of YAML such as `foo\::` (It include escape sequence.) are correct as a YAML syntax, but incorrect as a translation text.

I checked this test success. (It test script put to `/path/to/mt`)
A key like `foo::` (It not include escape sequence.) has no problem in `YAML::Syck` and `YAML::Tiny`.

``` perl```
use strict;
use warnings;

use lib qw(lib extlib t/lib);

use Test::More;

use MT;
use MT::Test;

sub test {
    my $module = shift;
    MT::Util::YAML::_find_module($module);
    is($MT::Util::YAML::Module, "MT::Util::$module", "YAMLModule is MT::Util::$module");
    my $yaml = <<YAML;
foo:: bar
YAML
    my $yaml_obj = MT::Util::YAML::Load($yaml);
    is((join '', keys %$yaml_obj), 'foo:', "foo:: is correct key for MT::Util::$module");
}

test $_ for (qw(YAML::Tiny YAML::Syck));

done_testing;
```

Or fix translation function.
